### PR TITLE
Support Windows and Lando properly, and test the container environments

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -45,6 +45,9 @@ openssl
 openvscode
 phpsab
 phpstan
+recognise
+recognised
+recognises
 repository
 setuptools
 shivammathur
@@ -53,6 +56,7 @@ starterkit
 startswith
 tokenless
 trixie
+unrecognised
 valeryan
 vfox
 xauth

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -45,6 +45,7 @@ openssl
 openvscode
 phpsab
 phpstan
+PKCE
 recognise
 recognised
 recognises

--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -1,3 +1,4 @@
+appserver
 behaviour
 bmewburn
 bootstrapvue
@@ -17,6 +18,8 @@ hverlin
 intelephense
 interruptible
 knip
+lando
+Landofile
 libasound
 libfreetype
 libgbm
@@ -29,6 +32,7 @@ libsqlite
 libxss
 libxtst
 libzip
+lndo
 makedirs
 mbstring
 namelist
@@ -37,6 +41,7 @@ nuxt
 nuxtjs
 nvmrc
 opcache
+openssl
 openvscode
 phpsab
 phpstan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,11 @@ jobs:
           WEBSERVER_HOST: 127.0.0.1
           WEBSERVER_PORT: 8888
 
+      # Anonymous JSON:API never touches OAuth, so nothing else here
+      # notices a consumer the backend cannot look up.
+      - name: OAuth consumer is recognised
+        run: npm run check:oauth
+
       - name: Install Nuxt dependencies
         working-directory: nuxt
         run: npm install
@@ -277,6 +282,10 @@ jobs:
         run: |
           . ./.env
           curl -sf "${BASE_URL}/jsonapi" | grep -q '"jsonapi"'
+
+      - name: OAuth consumer is recognised
+        working-directory: site
+        run: npm run check:oauth
 
       - name: Frontend builds against the live backend
         working-directory: site/nuxt

--- a/.github/workflows/environments.yml
+++ b/.github/workflows/environments.yml
@@ -53,7 +53,14 @@ jobs:
 
       - name: Create the OAuth consumer
         working-directory: drupal
-        run: ddev druxt-add-consumer
+        run: |
+          ddev druxt-add-consumer | tee /tmp/consumer.txt
+          grep -o 'OAUTH_CLIENT_ID=.*' /tmp/consumer.txt >> ../.env
+
+      # The container path builds its consumer with its own script, so
+      # the local path's coverage does not extend to it.
+      - name: OAuth consumer is recognised
+        run: npm run check:oauth
 
       # From inside the web container: no dependency on the runner
       # resolving *.ddev.site. -sS so a failure still prints why.
@@ -84,7 +91,9 @@ jobs:
 
       - name: Create the OAuth consumer
         working-directory: drupal
-        run: lando druxt-add-consumer
+        run: |
+          lando druxt-add-consumer | tee /tmp/consumer.txt
+          grep -o 'OAUTH_CLIENT_ID=.*' /tmp/consumer.txt >> ../.env
 
       # Checked from the host over the Lando URL, which is the path a
       # user actually takes. `via: nginx` puts the web server in its own
@@ -98,6 +107,9 @@ jobs:
           URL="${URL:-http://druxt-quickstart.lndo.site}"
           echo "Checking $URL/jsonapi"
           curl -sS "$URL/jsonapi" | tee /dev/stderr | grep -q '"jsonapi"'
+          # .env still holds the DDEV URL copied from .env.example.
+          sed -i "s#^BASE_URL=.*#BASE_URL=$URL#" ../.env
+          cd .. && npm run check:oauth
 
   devcontainer:
     name: Dev container

--- a/.github/workflows/environments.yml
+++ b/.github/workflows/environments.yml
@@ -107,8 +107,10 @@ jobs:
           URL="${URL:-http://druxt-quickstart.lndo.site}"
           echo "Checking $URL/jsonapi"
           curl -sS "$URL/jsonapi" | tee /dev/stderr | grep -q '"jsonapi"'
-          # .env still holds the DDEV URL copied from .env.example.
-          sed -i "s#^BASE_URL=.*#BASE_URL=$URL#" ../.env
+          # Write .env outright: unlike DDEV there is no hook seeding it,
+          # so a substitution has nothing to match and the check aborts.
+          printf 'BASE_URL=%s\n' "$URL" > ../.env
+          grep -o 'OAUTH_CLIENT_ID=.*' /tmp/consumer.txt >> ../.env
           cd .. && npm run check:oauth
 
   devcontainer:

--- a/.github/workflows/environments.yml
+++ b/.github/workflows/environments.yml
@@ -56,10 +56,10 @@ jobs:
         run: ddev druxt-add-consumer
 
       # From inside the web container: no dependency on the runner
-      # resolving *.ddev.site.
+      # resolving *.ddev.site. -sS so a failure still prints why.
       - name: JSON:API responds
         working-directory: drupal
-        run: ddev exec 'curl -sf http://localhost/jsonapi' | grep -q '"jsonapi"'
+        run: ddev exec 'curl -sS http://localhost/jsonapi' | tee /dev/stderr | grep -q '"jsonapi"'
 
   lando:
     name: Lando
@@ -86,9 +86,18 @@ jobs:
         working-directory: drupal
         run: lando druxt-add-consumer
 
+      # Checked from the host over the Lando URL, which is the path a
+      # user actually takes. `via: nginx` puts the web server in its own
+      # container, so localhost inside appserver serves nothing.
       - name: JSON:API responds
         working-directory: drupal
-        run: lando ssh -s appserver -c 'curl -sf http://localhost/jsonapi' | grep -q '"jsonapi"'
+        run: |
+          URL=$(lando info --format json 2>/dev/null \
+            | jq -r '.[] | select(.service == "appserver") | .urls[]?' \
+            | grep '^http://' | head -1)
+          URL="${URL:-http://druxt-quickstart.lndo.site}"
+          echo "Checking $URL/jsonapi"
+          curl -sS "$URL/jsonapi" | tee /dev/stderr | grep -q '"jsonapi"'
 
   devcontainer:
     name: Dev container

--- a/.github/workflows/environments.yml
+++ b/.github/workflows/environments.yml
@@ -13,8 +13,11 @@ on:
   push:
     paths: &environment-paths
       - '.devcontainer/**'
+      - '.env.example'
       - 'drupal/.ddev/**'
+      - 'drupal/.devtools/**'
       - 'drupal/.lando.yml'
+      - 'package.json'
       - 'drupal/composer.json'
       - 'drupal/composer.lock'
       - 'scripts/**'

--- a/.github/workflows/environments.yml
+++ b/.github/workflows/environments.yml
@@ -1,0 +1,111 @@
+name: Environments
+
+# The README offers four ways to run this starterkit. Three of them boot
+# containers, which the main CI never touches - it only exercises the
+# Docker-free path. These jobs cover the other three, so a broken DDEV
+# command or Landofile is found here rather than by someone following
+# the README.
+#
+# They are slow (container build plus a full Composer install), so they
+# run when the files they cover change, once a week to catch upstream
+# drift, and on demand - not on every push.
+on:
+  push:
+    paths: &environment-paths
+      - '.devcontainer/**'
+      - 'drupal/.ddev/**'
+      - 'drupal/.lando.yml'
+      - 'drupal/composer.json'
+      - 'drupal/composer.lock'
+      - 'scripts/**'
+      - '.github/workflows/environments.yml'
+  pull_request:
+    paths: *environment-paths
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: environments-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ddev:
+    name: DDEV
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Starts the project too (autostart defaults to true).
+      - uses: ddev/github-action-setup-ddev@v1
+        with:
+          ddevDir: drupal
+
+      - name: Install Drupal
+        working-directory: drupal
+        run: ddev drupal-install
+
+      - name: Create the OAuth consumer
+        working-directory: drupal
+        run: ddev druxt-add-consumer
+
+      # From inside the web container: no dependency on the runner
+      # resolving *.ddev.site.
+      - name: JSON:API responds
+        working-directory: drupal
+        run: ddev exec 'curl -sf http://localhost/jsonapi' | grep -q '"jsonapi"'
+
+  lando:
+    name: Lando
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Installs Lando only - unlike the DDEV action it does not start
+      # the app, so `lando start` is a step of its own below.
+      - uses: lando/setup-lando@v3
+
+      - name: Start Lando
+        working-directory: drupal
+        run: lando start
+
+      - name: Install Drupal
+        working-directory: drupal
+        run: lando drupal-install
+
+      - name: Create the OAuth consumer
+        working-directory: drupal
+        run: lando druxt-add-consumer
+
+      - name: JSON:API responds
+        working-directory: drupal
+        run: lando ssh -s appserver -c 'curl -sf http://localhost/jsonapi' | grep -q '"jsonapi"'
+
+  devcontainer:
+    name: Dev container
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # Builds devcontainer.json for real and runs post-create.sh, which
+      # is the same first-run a DevPod or VS Code user gets.
+      - uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          runCmd: |
+            set -e
+            npm run devtools -- start
+            . ./.env
+            curl -sf "${BASE_URL}/jsonapi" | grep -q '"jsonapi"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,7 +252,10 @@ test_e2e:
     - .devtools/assemble
     - .devtools/provision
     - .devtools/start
-    - cd ../nuxt
+    # Anonymous JSON:API never touches OAuth, so nothing else here
+    # notices a consumer the backend cannot look up.
+    - cd .. && npm run check:oauth
+    - cd nuxt
     - npm install
     - npx cypress install
     - npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Requires [Node 16](.nvmrc) and one of:
 
 - PHP 8.4 (with the pdo_sqlite extension) + Composer on your machine
   (Drush comes with the backend - no global install needed), or
-- [DDEV](https://ddev.readthedocs.io) (Docker)
+- [DDEV](https://ddev.readthedocs.io) or [Lando](https://lando.dev) (Docker)
+
+On Windows, use the [dev container](#development-container-vs-code-codespaces-devpod),
+WSL2, or a container backend - see [Windows](#windows).
 
 [nvm](https://github.com/nvm-sh/nvm) or [mise](https://mise.jdx.dev/) users:
 `nvm use` / `mise install` provides the pinned versions.
@@ -106,6 +109,50 @@ Using DDEV? Keep `BASE_URL` as the `*.ddev.site` URL in `.env`
 3. `npm run dev` as above. The DDEV backend is never auto-started or
    auto-stopped from the npm scripts.
 
+### Local development with [Lando](https://lando.dev)
+
+Set `BASE_URL` in `.env` to your Lando URL
+(`https://druxt-quickstart.lndo.site` for the bundled `drupal/.lando.yml`).
+Then:
+
+1. Frontend (from repository root):
+
+   ```bash
+   npm run setup
+   ```
+
+   Any non-loopback `BASE_URL` is treated as a backend this repo does not
+   manage, so this installs the frontend only.
+
+2. Backend (from `drupal/`):
+
+   ```bash
+   lando start
+   lando drupal-install
+   lando druxt-add-consumer
+   ```
+
+   `druxt-add-consumer` prints `OAUTH_CLIENT_ID=...` - copy it into
+   `.env`. Both commands run the same install steps as their DDEV
+   counterparts.
+
+3. `npm run dev` as above. `npm run drush -- <command>` is proxied
+   through `lando drush`.
+
+### Windows
+
+The local PHP backend does not run on Windows directly: it manages a PHP
+built-in server with `nohup`, `lsof`, `ps` and `kill`, and generates
+OAuth keys through OpenSSL. `npm run setup` says so rather than failing
+part-way through.
+
+Any of these work instead, with no changes to the repository:
+
+- the [dev container](#development-container-vs-code-codespaces-devpod),
+- WSL2, running the same commands inside your Linux distribution,
+- [DDEV](#local-development-with-ddev) or [Lando](#local-development-with-lando),
+  setting `BASE_URL` to the container URL.
+
 ### Development Container (VS Code, Codespaces, DevPod)
 
 `.devcontainer/devcontainer.json` gives you a ready environment: Node
@@ -158,6 +205,15 @@ DDEV is used to manage the Drupal instance, and provides a CLI that can be used 
 These commands should be run from within the `/drupal` folder.
 
 Refer to the documentation for more details: https://ddev.readthedocs.io
+
+### Lando
+
+> Lando is a free, open-source development tool that allows developers to
+> easily specify and construct the exact environment they need to build
+> their applications.
+
+- [lando.dev](https://lando.dev)
+- Config: [drupal/.lando.yml](drupal/.lando.yml)
 
 ### @nuxtjs/auth-next
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ Then:
 3. `npm run dev` as above. `npm run drush -- <command>` is proxied
    through `lando drush`.
 
+#### Login fails with invalid_client in a dev container
+
+The browser builds the OAuth callback from its own address. An IDE
+forwarding container port 3000 uses the next free host port when 3000 is
+taken (3001, 3002, ...), and Drupal rejects an unregistered callback as
+`invalid_client`. Provisioning registers `localhost:3000-3009/callback`
+to absorb this - if you land outside that range, free up host ports or
+re-provision with a matching `OAUTH_CALLBACK`.
+
 ### Windows
 
 The local PHP backend does not run on Windows directly: it manages a PHP

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ The browser builds the OAuth callback from its own address. An IDE
 forwarding container port 3000 uses the next free host port when 3000 is
 taken (3001, 3002, ...), and Drupal rejects an unregistered callback as
 `invalid_client`. Provisioning registers `localhost:3000-3009/callback`
-to absorb this - if you land outside that range, free up host ports or
-re-provision with a matching `OAUTH_CALLBACK`.
+to absorb this - if forwarding assigns a port outside that range, free
+up host ports or re-provision with a matching `OAUTH_CALLBACK`.
 
 ### Windows
 

--- a/drupal/.ddev/commands/web/drupal-install
+++ b/drupal/.ddev/commands/web/drupal-install
@@ -32,11 +32,12 @@ drush role:perm:add anonymous "access druxt resources"
 drush -y pm:enable simple_oauth
 
 # Configure and generate keys for Simple OAuth. Absolute path on purpose:
-# this command's cwd is /var/www/html (the mounted project root), so a
-# relative ../keys would land OUTSIDE the mount - ephemeral, and not the
-# drupal/keys/ location the config values below resolve to (they are
-# Drupal-side paths, resolved relative to the app root web/).
-KEYS_DIR="/var/www/html/keys"
+# this command's cwd is the mounted project root, so a relative ../keys
+# would land OUTSIDE the mount - ephemeral, and not the drupal/keys/
+# location the config values below resolve to (they are Drupal-side
+# paths, resolved relative to the app root web/). Derived rather than
+# hardcoded because DDEV mounts at /var/www/html and Lando at /app.
+KEYS_DIR="$(pwd)/keys"
 mkdir -p "$KEYS_DIR"
 drush -y config:set simple_oauth.settings public_key ../keys/public.key
 drush -y config:set simple_oauth.settings private_key ../keys/private.key

--- a/drupal/.ddev/commands/web/drupal-install
+++ b/drupal/.ddev/commands/web/drupal-install
@@ -8,40 +8,50 @@
 # half-provisioned site that later commands "fix" silently.
 set -euo pipefail
 
-# Install composer dependencies.
-composer install
+# Every path below is absolute and derived here, because this script runs
+# under both DDEV and Lando, which mount the project at different paths
+# and hand the script different working directories.
+if [ -f /var/www/html/composer.json ]; then
+  PROJECT_ROOT=/var/www/html            # DDEV
+elif [ -f /app/composer.json ]; then
+  PROJECT_ROOT=/app                     # Lando
+else
+  PROJECT_ROOT="$(pwd)"
+fi
+DRUPAL_ROOT="$PROJECT_ROOT/web"
 
-# Install a standard Drupal installation.
-drush -y site:install --site-name='quickstart-druxt-site' standard
+# Install composer dependencies.
+composer install --working-dir="$PROJECT_ROOT"
+
+# Install a standard Drupal installation. Drush is given the docroot
+# explicitly: DDEV's wrapper infers it, Lando's does not.
+drush -r "$DRUPAL_ROOT" -y site:install --site-name='quickstart-druxt-site' standard
 
 # Drupal 11's standard profile no longer creates content types itself -
 # Article and Page ship as separate core recipes. Without them there are
 # no node bundles, and jsonapi_views can't register a route for any
 # node-based view (including the front page).
-drush -y recipe:apply "$(pwd)/core/recipes/article_content_type"
-drush -y recipe:apply "$(pwd)/core/recipes/page_content_type"
-drush -y cache:rebuild
+drush -r "$DRUPAL_ROOT" -y recipe:apply "$DRUPAL_ROOT/core/recipes/article_content_type"
+drush -r "$DRUPAL_ROOT" -y recipe:apply "$DRUPAL_ROOT/core/recipes/page_content_type"
+drush -r "$DRUPAL_ROOT" -y cache:rebuild
 
 # Enable the Druxt module.
-drush -y pm:enable druxt
+drush -r "$DRUPAL_ROOT" -y pm:enable druxt
 
 # Allow the anonymous user read only access to required Druxt resources.
-drush role:perm:add anonymous "access druxt resources"
+drush -r "$DRUPAL_ROOT" role:perm:add anonymous "access druxt resources"
 
 # Enable the Simple OAuth module for authentication.
-drush -y pm:enable simple_oauth
+drush -r "$DRUPAL_ROOT" -y pm:enable simple_oauth
 
-# Configure and generate keys for Simple OAuth. Absolute path on purpose:
-# this command's cwd is the mounted project root, so a relative ../keys
-# would land OUTSIDE the mount - ephemeral, and not the drupal/keys/
-# location the config values below resolve to (they are Drupal-side
-# paths, resolved relative to the app root web/). Derived rather than
-# hardcoded because DDEV mounts at /var/www/html and Lando at /app.
-KEYS_DIR="$(pwd)/keys"
+# Keys live at the project root, NOT under the docroot: the config
+# values below are Drupal-side paths resolved relative to web/, so
+# ../keys from there is this directory.
+KEYS_DIR="$PROJECT_ROOT/keys"
 mkdir -p "$KEYS_DIR"
-drush -y config:set simple_oauth.settings public_key ../keys/public.key
-drush -y config:set simple_oauth.settings private_key ../keys/private.key
-drush simple-oauth:generate-keys "$KEYS_DIR"
+drush -r "$DRUPAL_ROOT" -y config:set simple_oauth.settings public_key ../keys/public.key
+drush -r "$DRUPAL_ROOT" -y config:set simple_oauth.settings private_key ../keys/private.key
+drush -r "$DRUPAL_ROOT" simple-oauth:generate-keys "$KEYS_DIR"
 
 # Enable authenticated editting via JSON:API.
-drush -y config:set jsonapi.settings read_only 0
+drush -r "$DRUPAL_ROOT" -y config:set jsonapi.settings read_only 0

--- a/drupal/.ddev/commands/web/drupal-install
+++ b/drupal/.ddev/commands/web/drupal-install
@@ -13,10 +13,18 @@ set -euo pipefail
 # and hand the script different working directories.
 if [ -f /var/www/html/composer.json ]; then
   PROJECT_ROOT=/var/www/html            # DDEV
+  # DDEV writes settings.ddev.php with the database credentials, so
+  # site:install finds them by itself.
+  DB_URL_ARG=""
 elif [ -f /app/composer.json ]; then
   PROJECT_ROOT=/app                     # Lando
+  # Lando writes no Drupal settings at all. Without credentials,
+  # site:install drops into its interactive database prompt and dies on
+  # a null driver. These are the drupal11 recipe's documented defaults.
+  DB_URL_ARG="--db-url=mysql://drupal11:drupal11@database/drupal11"
 else
   PROJECT_ROOT="$(pwd)"
+  DB_URL_ARG=""
 fi
 DRUPAL_ROOT="$PROJECT_ROOT/web"
 
@@ -25,7 +33,7 @@ composer install --working-dir="$PROJECT_ROOT"
 
 # Install a standard Drupal installation. Drush is given the docroot
 # explicitly: DDEV's wrapper infers it, Lando's does not.
-drush -r "$DRUPAL_ROOT" -y site:install --site-name='quickstart-druxt-site' standard
+drush -r "$DRUPAL_ROOT" -y site:install --site-name='quickstart-druxt-site' ${DB_URL_ARG:+"$DB_URL_ARG"} standard
 
 # Drupal 11's standard profile no longer creates content types itself -
 # Article and Page ship as separate core recipes. Without them there are

--- a/drupal/.ddev/commands/web/druxt-add-consumer
+++ b/drupal/.ddev/commands/web/druxt-add-consumer
@@ -15,9 +15,16 @@ fi
 
 # Create a Druxt consumer (simple_oauth 6.x Consumer entity).
 drush -r "$DRUPAL_ROOT" php-eval '
+$client_id = getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate();
 $consumer = \Drupal\consumers\Entity\Consumer::create([
   "owner_id"     => 1,
-  "uuid"         => getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate(),
+  // client_id, not just uuid: simple_oauth 6 looks consumers up by this
+  // field, and consumers only enforces it through form validation, so a
+  // programmatic save leaves it empty and every OAuth request fails with
+  // invalid_client. Same value as the uuid so one ID identifies the
+  // consumer everywhere.
+  "client_id"    => $client_id,
+  "uuid"         => $client_id,
   "label"        => "Druxt",
   "description"  => "DruxtJS is a bridge between frameworks, Drupal in the back, Nuxt in the front.\n\nhttps://druxtjs.org",
   "confidential" => FALSE,
@@ -25,5 +32,5 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
 ]);
 $consumer->save();
-echo "\nOAUTH_CLIENT_ID=" . $consumer->uuid->value . "\n\n";
+echo "\nOAUTH_CLIENT_ID=" . $consumer->getClientId() . "\n\n";
 '

--- a/drupal/.ddev/commands/web/druxt-add-consumer
+++ b/drupal/.ddev/commands/web/druxt-add-consumer
@@ -60,7 +60,16 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   // no scope (or an empty one, as druxt-auth does) resolves to this
   // rather than being rejected.
   "authorization_code_scopes" => [$scope_id],
-  "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
+  // Multi-value on purpose. The browser builds redirect_uri from its own
+  // origin, and an IDE forwarding container port 3000 lands on the next
+  // free HOST port (3001, 3002, ...) when 3000 is taken - league then
+  // rejects the unregistered redirect_uri as, confusingly,
+  // invalid_client. Registering the nearby ports keeps login working in
+  // forwarded dev sessions.
+  "redirect"     => array_values(array_unique(array_merge(
+    [getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback"],
+    array_map(fn ($port) => "http://localhost:{$port}/callback", range(3000, 3009)),
+  ))),
 ]);
 // Validate before saving: these fields are required, but only the
 // entity form enforces that, so a programmatic save silently produces a

--- a/drupal/.ddev/commands/web/druxt-add-consumer
+++ b/drupal/.ddev/commands/web/druxt-add-consumer
@@ -4,8 +4,17 @@
 ## Usage: druxt-add-consumer
 ## Example: "ddev druxt-add-consumer"
 
+# Same dual-mount resolution as drupal-install.
+if [ -f /var/www/html/composer.json ]; then
+  DRUPAL_ROOT=/var/www/html/web          # DDEV
+elif [ -f /app/composer.json ]; then
+  DRUPAL_ROOT=/app/web                   # Lando
+else
+  DRUPAL_ROOT="$(pwd)/web"
+fi
+
 # Create a Druxt consumer (simple_oauth 6.x Consumer entity).
-drush php-eval '
+drush -r "$DRUPAL_ROOT" php-eval '
 $consumer = \Drupal\consumers\Entity\Consumer::create([
   "owner_id"     => 1,
   "uuid"         => getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate(),

--- a/drupal/.ddev/commands/web/druxt-add-consumer
+++ b/drupal/.ddev/commands/web/druxt-add-consumer
@@ -15,6 +15,28 @@ fi
 
 # Create a Druxt consumer (simple_oauth 6.x Consumer entity).
 drush -r "$DRUPAL_ROOT" php-eval '
+// Simple OAuth 6 rejects an authorize request when it cannot resolve a
+// scope, and its default provider is "Dynamic (entity)" with no scopes
+// shipped - so a fresh site has none and every login fails with
+// "Check the `scope` parameter", whether the frontend sends a scope or
+// not. Create one and make it the consumer default, which is what
+// ScopeRepository::finalizeScopes() falls back to.
+$scope_id = "druxt";
+if (!\Drupal::entityTypeManager()->getStorage("oauth2_scope")->load($scope_id)) {
+  \Drupal\simple_oauth\Entity\Oauth2Scope::create([
+    "id" => $scope_id,
+    "name" => $scope_id,
+    "description" => "Access granted to the Druxt frontend.",
+    "grant_types" => [
+      "authorization_code" => ["status" => TRUE, "description" => "Authorization code grant."],
+      "refresh_token" => ["status" => TRUE, "description" => "Refresh token grant."],
+    ],
+    "umbrella" => FALSE,
+    "granularity_id" => "role",
+    "granularity_configuration" => ["role" => "authenticated"],
+  ])->save();
+}
+
 $client_id = getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate();
 $consumer = \Drupal\consumers\Entity\Consumer::create([
   "owner_id"     => 1,
@@ -34,6 +56,10 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   // fails with unsupported_grant_type. refresh_token lets the frontend
   // renew a session without sending the user back through login.
   "grant_types"  => ["authorization_code", "refresh_token"],
+  // The default scope for this grant: with it set, a request that sends
+  // no scope (or an empty one, as druxt-auth does) resolves to this
+  // rather than being rejected.
+  "authorization_code_scopes" => [$scope_id],
   "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
 ]);
 // Validate before saving: these fields are required, but only the

--- a/drupal/.ddev/commands/web/druxt-add-consumer
+++ b/drupal/.ddev/commands/web/druxt-add-consumer
@@ -29,8 +29,26 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   "description"  => "DruxtJS is a bridge between frameworks, Drupal in the back, Nuxt in the front.\n\nhttps://druxtjs.org",
   "confidential" => FALSE,
   "pkce"         => TRUE,
+  // Required by simple_oauth 6 and, like client_id, enforced only in the
+  // form - a programmatic save leaves it empty and the token request
+  // fails with unsupported_grant_type. refresh_token lets the frontend
+  // renew a session without sending the user back through login.
+  "grant_types"  => ["authorization_code", "refresh_token"],
   "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
 ]);
+// Validate before saving: these fields are required, but only the
+// entity form enforces that, so a programmatic save silently produces a
+// consumer that cannot authenticate. Two separate bugs shipped that way
+// (empty client_id, empty grant_types), each surfacing only as a failed
+// login. Fail here instead.
+$violations = $consumer->validate();
+if ($violations->count() > 0) {
+  $messages = [];
+  foreach ($violations as $violation) {
+    $messages[] = $violation->getPropertyPath() . ": " . strip_tags((string) $violation->getMessage());
+  }
+  throw new \RuntimeException("Refusing to save an invalid Consumer - " . implode("; ", $messages));
+}
 $consumer->save();
 echo "\nOAUTH_CLIENT_ID=" . $consumer->getClientId() . "\n\n";
 '

--- a/drupal/.ddev/config.yaml
+++ b/drupal/.ddev/config.yaml
@@ -16,6 +16,14 @@ use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
 
+# docker-compose.env.yaml mounts ../.env into the container, and Docker
+# fails the whole start when that file is missing. It is gitignored, so
+# a fresh clone has none until setup runs - seed it from the example so
+# `ddev start` works straight after cloning.
+hooks:
+  pre-start:
+    - exec-host: "test -f ../.env || cp ../.env.example ../.env"
+
 # Key features of ddev's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides

--- a/drupal/.devtools/provision
+++ b/drupal/.devtools/provision
@@ -134,8 +134,26 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   "description"  => "DruxtJS is a bridge between frameworks, Drupal in the back, Nuxt in the front.\n\nhttps://druxtjs.org",
   "confidential" => FALSE,
   "pkce"         => TRUE,
+  // Required by simple_oauth 6 and, like client_id, enforced only in the
+  // form - a programmatic save leaves it empty and the token request
+  // fails with unsupported_grant_type. refresh_token lets the frontend
+  // renew a session without sending the user back through login.
+  "grant_types"  => ["authorization_code", "refresh_token"],
   "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
 ]);
+// Validate before saving: these fields are required, but only the
+// entity form enforces that, so a programmatic save silently produces a
+// consumer that cannot authenticate. Two separate bugs shipped that way
+// (empty client_id, empty grant_types), each surfacing only as a failed
+// login. Fail here instead.
+$violations = $consumer->validate();
+if ($violations->count() > 0) {
+  $messages = [];
+  foreach ($violations as $violation) {
+    $messages[] = $violation->getPropertyPath() . ": " . strip_tags((string) $violation->getMessage());
+  }
+  throw new \RuntimeException("Refusing to save an invalid Consumer - " . implode("; ", $messages));
+}
 $consumer->save();
 PHP);
 dotenv_write_var('OAUTH_CLIENT_ID', $client_id);

--- a/drupal/.devtools/provision
+++ b/drupal/.devtools/provision
@@ -165,7 +165,16 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   // no scope (or an empty one, as druxt-auth does) resolves to this
   // rather than being rejected.
   "authorization_code_scopes" => [$scope_id],
-  "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
+  // Multi-value on purpose. The browser builds redirect_uri from its own
+  // origin, and an IDE forwarding container port 3000 lands on the next
+  // free HOST port (3001, 3002, ...) when 3000 is taken - league then
+  // rejects the unregistered redirect_uri as, confusingly,
+  // invalid_client. Registering the nearby ports keeps login working in
+  // forwarded dev sessions.
+  "redirect"     => array_values(array_unique(array_merge(
+    [getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback"],
+    array_map(fn ($port) => "http://localhost:{$port}/callback", range(3000, 3009)),
+  ))),
 ]);
 // Validate before saving: these fields are required, but only the
 // entity form enforces that, so a programmatic save silently produces a

--- a/drupal/.devtools/provision
+++ b/drupal/.devtools/provision
@@ -120,9 +120,16 @@ $client_id = generate_uuid();
 putenv('OAUTH_CLIENT_ID=' . $client_id);
 putenv('OAUTH_CALLBACK=' . $oauth_callback);
 drush('php-eval %s', <<<'PHP'
+$client_id = getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate();
 $consumer = \Drupal\consumers\Entity\Consumer::create([
   "owner_id"     => 1,
-  "uuid"         => getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate(),
+  // client_id, not just uuid: simple_oauth 6 looks consumers up by this
+  // field, and consumers only enforces it through form validation, so a
+  // programmatic save leaves it empty and every OAuth request fails with
+  // invalid_client. Same value as the uuid so one ID identifies the
+  // consumer everywhere.
+  "client_id"    => $client_id,
+  "uuid"         => $client_id,
   "label"        => "Druxt",
   "description"  => "DruxtJS is a bridge between frameworks, Drupal in the back, Nuxt in the front.\n\nhttps://druxtjs.org",
   "confidential" => FALSE,

--- a/drupal/.devtools/provision
+++ b/drupal/.devtools/provision
@@ -120,6 +120,28 @@ $client_id = generate_uuid();
 putenv('OAUTH_CLIENT_ID=' . $client_id);
 putenv('OAUTH_CALLBACK=' . $oauth_callback);
 drush('php-eval %s', <<<'PHP'
+// Simple OAuth 6 rejects an authorize request when it cannot resolve a
+// scope, and its default provider is "Dynamic (entity)" with no scopes
+// shipped - so a fresh site has none and every login fails with
+// "Check the `scope` parameter", whether the frontend sends a scope or
+// not. Create one and make it the consumer default, which is what
+// ScopeRepository::finalizeScopes() falls back to.
+$scope_id = "druxt";
+if (!\Drupal::entityTypeManager()->getStorage("oauth2_scope")->load($scope_id)) {
+  \Drupal\simple_oauth\Entity\Oauth2Scope::create([
+    "id" => $scope_id,
+    "name" => $scope_id,
+    "description" => "Access granted to the Druxt frontend.",
+    "grant_types" => [
+      "authorization_code" => ["status" => TRUE, "description" => "Authorization code grant."],
+      "refresh_token" => ["status" => TRUE, "description" => "Refresh token grant."],
+    ],
+    "umbrella" => FALSE,
+    "granularity_id" => "role",
+    "granularity_configuration" => ["role" => "authenticated"],
+  ])->save();
+}
+
 $client_id = getenv("OAUTH_CLIENT_ID") ?: \Drupal::service("uuid")->generate();
 $consumer = \Drupal\consumers\Entity\Consumer::create([
   "owner_id"     => 1,
@@ -139,6 +161,10 @@ $consumer = \Drupal\consumers\Entity\Consumer::create([
   // fails with unsupported_grant_type. refresh_token lets the frontend
   // renew a session without sending the user back through login.
   "grant_types"  => ["authorization_code", "refresh_token"],
+  // The default scope for this grant: with it set, a request that sends
+  // no scope (or an empty one, as druxt-auth does) resolves to this
+  // rather than being rejected.
+  "authorization_code_scopes" => [$scope_id],
   "redirect"     => getenv("OAUTH_CALLBACK") ?: "http://localhost:3000/callback",
 ]);
 // Validate before saving: these fields are required, but only the

--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -11,17 +11,23 @@ config:
 
 # The install steps are the ones DDEV runs - one copy, so the two
 # container workflows cannot drift apart. Lando mounts this directory
-# (the Landofile's own directory) at /app, and both scripts expect the
-# project root as their working directory, which is where tooling
-# commands run by default.
+# (the Landofile's own directory) at /app; the scripts resolve their own
+# paths from that mount, and the install commands below pin their
+# working directory so it cannot depend on where they were called from.
 tooling:
   drupal-install:
     service: appserver
+    # Pinned: without this Lando mirrors the caller's directory, so
+    # running it from drupal/web would put the container in /app/web.
+    dir: /app
     description: Install Drupal and configure it for DruxtSite
     cmd: bash /app/.ddev/commands/web/drupal-install
 
   druxt-add-consumer:
     service: appserver
+    # Pinned: without this Lando mirrors the caller's directory, so
+    # running it from drupal/web would put the container in /app/web.
+    dir: /app
     description: Create the Simple OAuth consumer the Nuxt frontend authenticates with
     cmd: bash /app/.ddev/commands/web/druxt-add-consumer
 

--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -1,0 +1,29 @@
+name: druxt-quickstart
+recipe: drupal11
+
+config:
+  webroot: web
+  php: '8.4'
+  database: mariadb:11.4
+  via: nginx
+  composer_version: '2'
+  xdebug: false
+
+# The install steps are the ones DDEV runs - one copy, so the two
+# container workflows cannot drift apart. Lando mounts this directory
+# (the Landofile's own directory) at /app, and both scripts expect the
+# project root as their working directory, which is where tooling
+# commands run by default.
+tooling:
+  drupal-install:
+    service: appserver
+    description: Install Drupal and configure it for DruxtSite
+    cmd: bash /app/.ddev/commands/web/drupal-install
+
+  druxt-add-consumer:
+    service: appserver
+    description: Create the Simple OAuth consumer the Nuxt frontend authenticates with
+    cmd: bash /app/.ddev/commands/web/druxt-add-consumer
+
+  drush:
+    service: appserver

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "drush": "node scripts/drush.mjs",
     "xdebug": "node scripts/xdebug.mjs",
     "info": "node scripts/info.mjs",
+    "check:oauth": "node scripts/check-oauth.mjs",
     "reset": "node scripts/reset.mjs",
     "postinstall": "node scripts/postinstall.mjs",
     "lint:js": "eslint scripts",

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -17,6 +17,16 @@ import http from 'node:http'
 import https from 'node:https'
 import { exitWithError, readEnv } from './lib.mjs'
 
+/** OAuth errors carry the useful detail in `hint`; surface it. */
+function describe(response) {
+  try {
+    const parsed = JSON.parse(response.body)
+    return `${parsed.error || '?'} - ${parsed.hint || parsed.error_description || ''}`
+  } catch {
+    return response.body.slice(0, 300).replace(/\s+/g, ' ')
+  }
+}
+
 function request(url, postBody) {
   return new Promise((resolve, reject) => {
     const client = url.protocol === 'https:' ? https : http
@@ -75,7 +85,7 @@ async function main() {
 
   console.log(`OAuth consumer recognised (HTTP ${status}).`)
   if (status >= 400) {
-    console.log(`  (authorize returned ${status}: ${body.slice(0, 200).replace(/\s+/g, ' ')})`)
+    console.log(`  authorize without scope -> ${describe({ status, body })}`)
   }
 
   // Being recognised is not enough: the consumer also has to have the
@@ -119,11 +129,9 @@ async function main() {
     console.warn('  Note: this backend rejects the empty `scope=` that druxt-auth sends')
     console.warn('  by default, so the login button will fail with invalid_request.')
     console.warn('  Configure druxt.auth.scope, and see druxt/druxt-auth#35.')
+    console.warn(`  empty scope -> ${describe(emptyScope)}`)
   } else if (emptyScope.status !== status) {
-    console.log(
-      `Empty scope changed the response (HTTP ${emptyScope.status}): ` +
-        emptyScope.body.slice(0, 200).replace(/\s+/g, ' ')
-    )
+    console.log(`  empty scope -> ${describe(emptyScope)}`)
   } else {
     console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
   }

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -17,6 +17,47 @@ import http from 'node:http'
 import https from 'node:https'
 import { exitWithError, readEnv } from './lib.mjs'
 
+function parse(response) {
+  try {
+    return JSON.parse(response.body)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * A usable authorize endpoint sends the visitor to the login form. Treat
+ * everything else as a failure, including responses this script does not
+ * recognise: an earlier version only looked for known error strings, so
+ * unrelated failures were reported as passes.
+ */
+function assertAuthorizeAccepted(response, label, env) {
+  if ([200, 301, 302, 303, 307, 308].includes(response.status)) {
+    return
+  }
+
+  const error = parse(response)
+  if (error && error.error === 'invalid_client') {
+    exitWithError(
+      `Drupal does not recognise OAUTH_CLIENT_ID (${env.OAUTH_CLIENT_ID}).\n\n` +
+        '  Login fails while the rest of the site works, because anonymous\n' +
+        '  JSON:API never touches OAuth.\n\n' +
+        '  Re-run `npm run provision` to recreate the consumer.'
+    )
+  }
+  if (error && String(error.hint || '').includes('scope')) {
+    exitWithError(
+      `The backend cannot resolve a scope for this consumer (${label}).\n\n` +
+        `  ${describe(response)}\n\n` +
+        '  Provisioning must create an oauth2_scope and set it as the\n' +
+        "  consumer's authorization_code_scopes. Re-run `npm run provision`."
+    )
+  }
+  exitWithError(
+    `Unexpected answer from ${label} (HTTP ${response.status}).\n\n  ${describe(response)}`
+  )
+}
+
 /** OAuth errors carry the useful detail in `hint`; surface it. */
 function describe(response) {
   try {
@@ -71,27 +112,15 @@ async function main() {
   url.searchParams.set('code_challenge', challenge)
   url.searchParams.set('code_challenge_method', 'S256')
 
-  const { status, body } = await request(url)
+  const authorize = await request(url)
+  assertAuthorizeAccepted(authorize, 'authorize', env)
+  console.log(`OAuth consumer recognised (HTTP ${authorize.status}).`)
 
-  if (body.includes('invalid_client')) {
-    exitWithError(
-      `Drupal does not recognise OAUTH_CLIENT_ID (${env.OAUTH_CLIENT_ID}).\n\n` +
-        '  Login fails with {"error":"invalid_client"} while the rest of the site\n' +
-        '  works, because anonymous JSON:API never touches OAuth.\n\n' +
-        '  Re-run `npm run provision` to recreate the consumer, then check that\n' +
-        '  OAUTH_CLIENT_ID in .env matches its Client ID field.'
-    )
-  }
-
-  console.log(`OAuth consumer recognised (HTTP ${status}).`)
-  if (status >= 400) {
-    console.log(`  authorize without scope -> ${describe({ status, body })}`)
-  }
-
-  // Being recognised is not enough: the consumer also has to have the
-  // authorization_code grant enabled, or the code exchange fails with
-  // unsupported_grant_type after the user has already logged in. Sending
-  // a deliberately invalid code is enough to tell the two apart.
+  // Being recognised is not enough: the consumer also needs the
+  // authorization_code grant, or login fails at the code exchange after
+  // the user has already signed in. A deliberately invalid code should
+  // be rejected as a bad *code* - any other answer means something else
+  // is wrong.
   const tokenUrl = new URL('/oauth/token', env.BASE_URL)
   const form = new URLSearchParams({
     grant_type: 'authorization_code',
@@ -102,41 +131,35 @@ async function main() {
   }).toString()
 
   const token = await request(tokenUrl, form)
+  const tokenError = parse(token)
 
-  if (token.body.includes('unsupported_grant_type')) {
+  if (!tokenError || typeof tokenError.error !== 'string') {
+    exitWithError(
+      `Unexpected answer from the token endpoint (HTTP ${token.status}).\n\n  ${describe(token)}`
+    )
+  }
+  if (tokenError.error === 'unsupported_grant_type') {
     exitWithError(
       'The consumer does not have the authorization_code grant enabled.\n\n' +
-        '  Login gets as far as the code exchange and then fails with\n' +
-        '  {"error":"unsupported_grant_type"}.\n\n' +
+        '  Login reaches the code exchange and fails there.\n' +
         '  Re-run `npm run provision` to recreate the consumer.'
     )
   }
-
+  if (tokenError.error !== 'invalid_grant' && tokenError.error !== 'invalid_request') {
+    exitWithError(
+      `The token endpoint rejected the exchange for an unexpected reason.\n\n  ${describe(token)}`
+    )
+  }
   console.log('Authorization code grant enabled.')
 
-  // druxt-auth sends `scope=` empty: @nuxtjs/auth-next defaults the
-  // option to [], its getter joins that to '', and its query encoder
-  // drops undefined but keeps empty strings. Probing with the same
-  // parameter tells us whether that empty value is what Drupal rejects,
-  // separately from anything this repo controls. Reported, not fatal -
-  // the fix for it lives in druxt-auth.
+  // druxt-auth sends `scope=` empty (@nuxtjs/auth-next defaults the
+  // option to [] and its encoder keeps empty strings), so the real login
+  // request has to be accepted with that parameter present too.
   const emptyScopeUrl = new URL(url)
   emptyScopeUrl.searchParams.set('scope', '')
   const emptyScope = await request(emptyScopeUrl)
-
-  if (emptyScope.body.includes('Check the `scope` parameter')) {
-    exitWithError(
-      'The backend cannot resolve a scope for this consumer.\n\n' +
-        `  ${describe(emptyScope)}\n\n` +
-        '  Login fails with invalid_request whether the frontend sends a scope\n' +
-        '  or not, so provisioning must create an oauth2_scope and set it as the\n' +
-        "  consumer's authorization_code_scopes. Re-run `npm run provision`."
-    )
-  } else if (emptyScope.status !== status) {
-    console.log(`  empty scope -> ${describe(emptyScope)}`)
-  } else {
-    console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
-  }
+  assertAuthorizeAccepted(emptyScope, 'authorize with an empty scope', env)
+  console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
 }
 
 main().catch((error) => exitWithError(`OAuth check failed: ${error.message}`))

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -92,6 +92,25 @@ async function main() {
   }
 
   console.log('Authorization code grant enabled.')
+
+  // druxt-auth sends `scope=` empty: @nuxtjs/auth-next defaults the
+  // option to [], its getter joins that to '', and its query encoder
+  // drops undefined but keeps empty strings. Probing with the same
+  // parameter tells us whether that empty value is what Drupal rejects,
+  // separately from anything this repo controls. Reported, not fatal -
+  // the fix for it lives in druxt-auth.
+  const emptyScopeUrl = new URL(url)
+  emptyScopeUrl.searchParams.set('scope', '')
+  const emptyScope = await request(emptyScopeUrl)
+
+  if (emptyScope.body.includes('Check the `scope` parameter')) {
+    console.warn('')
+    console.warn('  Note: this backend rejects the empty `scope=` that druxt-auth sends')
+    console.warn('  by default, so the login button will fail with invalid_request.')
+    console.warn('  Configure druxt.auth.scope, and see druxt/druxt-auth#35.')
+  } else {
+    console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
+  }
 }
 
 main().catch((error) => exitWithError(`OAuth check failed: ${error.message}`))

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -16,10 +16,18 @@ import http from 'node:http'
 import https from 'node:https'
 import { exitWithError, readEnv } from './lib.mjs'
 
-function request(url) {
+function request(url, postBody) {
   return new Promise((resolve, reject) => {
     const client = url.protocol === 'https:' ? https : http
-    const req = client.get(url, { timeout: 10000 }, (res) => {
+    const options = { timeout: 10000 }
+    if (postBody !== undefined) {
+      options.method = 'POST'
+      options.headers = {
+        'content-type': 'application/x-www-form-urlencoded',
+        'content-length': Buffer.byteLength(postBody),
+      }
+    }
+    const req = client.request(url, options, (res) => {
       let body = ''
       res.on('data', (chunk) => {
         body += chunk
@@ -28,6 +36,7 @@ function request(url) {
     })
     req.on('timeout', () => req.destroy(new Error('timed out')))
     req.on('error', reject)
+    req.end(postBody)
   })
 }
 
@@ -57,6 +66,32 @@ async function main() {
   }
 
   console.log(`OAuth consumer recognised (HTTP ${status}).`)
+
+  // Being recognised is not enough: the consumer also has to have the
+  // authorization_code grant enabled, or the code exchange fails with
+  // unsupported_grant_type after the user has already logged in. Sending
+  // a deliberately invalid code is enough to tell the two apart.
+  const tokenUrl = new URL('/oauth/token', env.BASE_URL)
+  const form = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: env.OAUTH_CLIENT_ID,
+    redirect_uri: env.OAUTH_CALLBACK || 'http://localhost:3000/callback',
+    code: 'not-a-real-code',
+    code_verifier: 'not-a-real-verifier',
+  }).toString()
+
+  const token = await request(tokenUrl, form)
+
+  if (token.body.includes('unsupported_grant_type')) {
+    exitWithError(
+      'The consumer does not have the authorization_code grant enabled.\n\n' +
+        '  Login gets as far as the code exchange and then fails with\n' +
+        '  {"error":"unsupported_grant_type"}.\n\n' +
+        '  Re-run `npm run provision` to recreate the consumer.'
+    )
+  }
+
+  console.log('Authorization code grant enabled.')
 }
 
 main().catch((error) => exitWithError(`OAuth check failed: ${error.message}`))

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -12,6 +12,7 @@
  * unrecognised one is rejected outright.
  */
 
+import crypto from 'node:crypto'
 import http from 'node:http'
 import https from 'node:https'
 import { exitWithError, readEnv } from './lib.mjs'
@@ -48,10 +49,17 @@ async function main() {
     )
   }
 
+  // The consumer requires PKCE, so a request without a challenge is
+  // rejected before anything else is looked at - including the scope.
+  const verifier = 'quickstart-oauth-check-verifier-0123456789'
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url')
+
   const url = new URL('/oauth/authorize', env.BASE_URL)
   url.searchParams.set('response_type', 'code')
   url.searchParams.set('client_id', env.OAUTH_CLIENT_ID)
   url.searchParams.set('redirect_uri', env.OAUTH_CALLBACK || 'http://localhost:3000/callback')
+  url.searchParams.set('code_challenge', challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
 
   const { status, body } = await request(url)
 
@@ -66,6 +74,9 @@ async function main() {
   }
 
   console.log(`OAuth consumer recognised (HTTP ${status}).`)
+  if (status >= 400) {
+    console.log(`  (authorize returned ${status}: ${body.slice(0, 200).replace(/\s+/g, ' ')})`)
+  }
 
   // Being recognised is not enough: the consumer also has to have the
   // authorization_code grant enabled, or the code exchange fails with
@@ -108,6 +119,11 @@ async function main() {
     console.warn('  Note: this backend rejects the empty `scope=` that druxt-auth sends')
     console.warn('  by default, so the login button will fail with invalid_request.')
     console.warn('  Configure druxt.auth.scope, and see druxt/druxt-auth#35.')
+  } else if (emptyScope.status !== status) {
+    console.log(
+      `Empty scope changed the response (HTTP ${emptyScope.status}): ` +
+        emptyScope.body.slice(0, 200).replace(/\s+/g, ' ')
+    )
   } else {
     console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
   }

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -125,11 +125,13 @@ async function main() {
   const emptyScope = await request(emptyScopeUrl)
 
   if (emptyScope.body.includes('Check the `scope` parameter')) {
-    console.warn('')
-    console.warn('  Note: this backend rejects the empty `scope=` that druxt-auth sends')
-    console.warn('  by default, so the login button will fail with invalid_request.')
-    console.warn('  Configure druxt.auth.scope, and see druxt/druxt-auth#35.')
-    console.warn(`  empty scope -> ${describe(emptyScope)}`)
+    exitWithError(
+      'The backend cannot resolve a scope for this consumer.\n\n' +
+        `  ${describe(emptyScope)}\n\n` +
+        '  Login fails with invalid_request whether the frontend sends a scope\n' +
+        '  or not, so provisioning must create an oauth2_scope and set it as the\n' +
+        "  consumer's authorization_code_scopes. Re-run `npm run provision`."
+    )
   } else if (emptyScope.status !== status) {
     console.log(`  empty scope -> ${describe(emptyScope)}`)
   } else {

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -15,6 +15,8 @@
 import crypto from 'node:crypto'
 import http from 'node:http'
 import https from 'node:https'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { exitWithError, readEnv } from './lib.mjs'
 
 function parse(response) {
@@ -92,7 +94,7 @@ function request(url, postBody) {
   })
 }
 
-async function main() {
+export async function checkOauth() {
   const env = readEnv()
   if (!env.BASE_URL || !env.OAUTH_CLIENT_ID) {
     exitWithError(
@@ -162,4 +164,9 @@ async function main() {
   console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
 }
 
-main().catch((error) => exitWithError(`OAuth check failed: ${error.message}`))
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+
+if (invokedDirectly) {
+  checkOauth().catch((error) => exitWithError(`OAuth check failed: ${error.message}`))
+}

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -162,6 +162,29 @@ export async function checkOauth() {
   const emptyScope = await request(emptyScopeUrl)
   assertAuthorizeAccepted(emptyScope, 'authorize with an empty scope', env)
   console.log(`Empty scope accepted (HTTP ${emptyScope.status}).`)
+
+  // The browser builds redirect_uri from its own origin. When an IDE
+  // forwards container port 3000 to another host port, that origin no
+  // longer matches the registered callback and Drupal answers - very
+  // confusingly - invalid_client. Provisioning registers localhost
+  // 3000-3009 to absorb that; verify a couple of them here so a
+  // regression names itself.
+  for (const port of [3001, 3005]) {
+    const fwd = new URL(url)
+    fwd.searchParams.set('redirect_uri', `http://localhost:${port}/callback`)
+    const res = await request(fwd)
+    const err = parse(res)
+    if (err && err.error === 'invalid_client') {
+      exitWithError(
+        `The callback for a forwarded port (localhost:${port}) is not registered.\n\n` +
+          '  Browsers reach forwarded dev servers on whatever host port the IDE\n' +
+          '  could grab, and Drupal rejects an unregistered redirect_uri as\n' +
+          '  invalid_client. Re-run `npm run provision` to register the 3000-3009\n' +
+          '  callback range.'
+      )
+    }
+  }
+  console.log('Forwarded-port callbacks (3000-3009) registered.')
 }
 
 const invokedDirectly =

--- a/scripts/check-oauth.mjs
+++ b/scripts/check-oauth.mjs
@@ -1,0 +1,62 @@
+/**
+ * Verify that the backend recognises the consumer in .env.
+ *
+ * The frontend's login button sends OAUTH_CLIENT_ID to /oauth/authorize.
+ * If no consumer matches, Drupal answers `invalid_client` and the only
+ * visible symptom is a failed login - the site otherwise looks fine,
+ * because anonymous JSON:API does not involve OAuth at all. That is how
+ * a consumer saved without its `client_id` field reached users twice.
+ *
+ * A recognised client gets past client validation (a redirect to the
+ * login form, or a complaint about some other parameter). An
+ * unrecognised one is rejected outright.
+ */
+
+import http from 'node:http'
+import https from 'node:https'
+import { exitWithError, readEnv } from './lib.mjs'
+
+function request(url) {
+  return new Promise((resolve, reject) => {
+    const client = url.protocol === 'https:' ? https : http
+    const req = client.get(url, { timeout: 10000 }, (res) => {
+      let body = ''
+      res.on('data', (chunk) => {
+        body += chunk
+      })
+      res.on('end', () => resolve({ status: res.statusCode, body }))
+    })
+    req.on('timeout', () => req.destroy(new Error('timed out')))
+    req.on('error', reject)
+  })
+}
+
+async function main() {
+  const env = readEnv()
+  if (!env.BASE_URL || !env.OAUTH_CLIENT_ID) {
+    exitWithError(
+      'BASE_URL and OAUTH_CLIENT_ID must both be set in .env - run `npm run setup` first.'
+    )
+  }
+
+  const url = new URL('/oauth/authorize', env.BASE_URL)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('client_id', env.OAUTH_CLIENT_ID)
+  url.searchParams.set('redirect_uri', env.OAUTH_CALLBACK || 'http://localhost:3000/callback')
+
+  const { status, body } = await request(url)
+
+  if (body.includes('invalid_client')) {
+    exitWithError(
+      `Drupal does not recognise OAUTH_CLIENT_ID (${env.OAUTH_CLIENT_ID}).\n\n` +
+        '  Login fails with {"error":"invalid_client"} while the rest of the site\n' +
+        '  works, because anonymous JSON:API never touches OAuth.\n\n' +
+        '  Re-run `npm run provision` to recreate the consumer, then check that\n' +
+        '  OAUTH_CLIENT_ID in .env matches its Client ID field.'
+    )
+  }
+
+  console.log(`OAuth consumer recognised (HTTP ${status}).`)
+}
+
+main().catch((error) => exitWithError(`OAuth check failed: ${error.message}`))

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -43,9 +43,43 @@ async function ensureFrontendPortFree() {
   )
 }
 
+/**
+ * The consumer is registered for one callback URL. Serving the frontend
+ * on a different port than that URL names fails the same way a busy
+ * port does, just without anything else looking wrong.
+ */
+function ensureCallbackMatchesPort() {
+  const callback = readEnv().OAUTH_CALLBACK
+  if (!callback) {
+    return
+  }
+
+  let parsed
+  try {
+    parsed = new URL(callback)
+  } catch {
+    return
+  }
+
+  const callbackPort = Number(parsed.port) || (parsed.protocol === 'https:' ? 443 : 80)
+  if (callbackPort === PORT) {
+    return
+  }
+
+  exitWithError(
+    `OAUTH_CALLBACK names port ${callbackPort}, but the dev server would run on ${PORT}.\n\n` +
+      `  Login would fail with {"error":"invalid_client"} - Drupal only accepts the\n` +
+      `  callback it has registered (${callback}).\n\n` +
+      `  Either start on that port with \`PORT=${callbackPort} npm run dev\`, or set\n` +
+      `  OAUTH_CALLBACK to port ${PORT} and re-run \`npm run provision\` to\n` +
+      `  re-register the consumer.`
+  )
+}
+
 async function main() {
   await ensureBackend()
   ensureOauthClientId()
+  ensureCallbackMatchesPort()
   await ensureFrontendPortFree()
   console.log(`Starting the Nuxt dev server -> http://localhost:${PORT}`)
   console.log('')

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -5,6 +5,7 @@
  * DDEV / remote backends are used as-is and never started from here.
  */
 
+import { checkOauth } from './check-oauth.mjs'
 import {
   NUXT_DIR,
   ensureBackend,
@@ -81,6 +82,11 @@ async function main() {
   ensureOauthClientId()
   ensureCallbackMatchesPort()
   await ensureFrontendPortFree()
+  // Confirm the backend will actually accept this consumer. Nuxt reads
+  // OAUTH_CLIENT_ID once at startup, so a stale value - or a consumer
+  // left over from an older provision - shows up only as a failed login
+  // in the browser, with nothing in the terminal to explain it.
+  await checkOauth()
   console.log(`Starting the Nuxt dev server -> http://localhost:${PORT}`)
   console.log('')
   process.exitCode = await foregroundNpm(['run', 'dev'], { cwd: NUXT_DIR })

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -5,11 +5,49 @@
  * DDEV / remote backends are used as-is and never started from here.
  */
 
-import { NUXT_DIR, ensureBackend, exitWithError, foregroundNpm } from './lib.mjs'
+import {
+  NUXT_DIR,
+  ensureBackend,
+  ensureOauthClientId,
+  exitWithError,
+  foregroundNpm,
+  isPortOpen,
+  readEnv,
+} from './lib.mjs'
+
+const PORT = Number(process.env.PORT) || 3000
+
+/**
+ * Refuse to start when the frontend port is taken.
+ *
+ * Nuxt's dev server does not fail on a busy port - it falls back to a
+ * random one. The OAuth consumer in Drupal is registered against a fixed
+ * callback URL, so the login round trip then fails with a bare
+ * `invalid_client` from Drupal, pointing nowhere near the real cause.
+ */
+async function ensureFrontendPortFree() {
+  if (!(await isPortOpen('127.0.0.1', PORT))) {
+    return
+  }
+
+  const callback = readEnv().OAUTH_CALLBACK || `http://localhost:${PORT}/callback`
+  exitWithError(
+    `Port ${PORT} is already in use.\n\n` +
+      `  Nuxt would fall back to a random port, and login would then fail with\n` +
+      `  {"error":"invalid_client"} - Drupal has the consumer registered for\n` +
+      `  ${callback}, which would no longer match.\n\n` +
+      `  Free the port (another dev server, or another copy of this project),\n` +
+      `  or commit to a different one: set OAUTH_CALLBACK in .env to the port\n` +
+      `  you want, re-run \`npm run provision\` to re-register the consumer,\n` +
+      `  then start with \`PORT=<port> npm run dev\`.`
+  )
+}
 
 async function main() {
   await ensureBackend()
-  console.log('Starting the Nuxt dev server -> http://localhost:3000')
+  ensureOauthClientId()
+  await ensureFrontendPortFree()
+  console.log(`Starting the Nuxt dev server -> http://localhost:${PORT}`)
   console.log('')
   process.exitCode = await foregroundNpm(['run', 'dev'], { cwd: NUXT_DIR })
 }

--- a/scripts/drush.mjs
+++ b/scripts/drush.mjs
@@ -12,13 +12,16 @@ const drushArgs = process.argv.slice(2)
 try {
   const backend = backendInfo()
 
-  if (backend.url && !backend.managed && !backend.ddev) {
+  if (backend.url && !backend.managed && !backend.ddev && !backend.lando) {
     exitWithError(
-      `BASE_URL (${backend.url}) points at a remote backend - Drush can only be run against the local backend or DDEV. Use that backend's own tooling instead.`
+      `BASE_URL (${backend.url}) points at a remote backend - Drush can only be run against the local backend, DDEV or Lando. Use that backend's own tooling instead.`
     )
   }
 
-  if (backend.ddev) {
+  if (backend.lando) {
+    // Inside Lando, drush must run in the container.
+    run('lando', ['drush', ...drushArgs], { cwd: DRUPAL_DIR })
+  } else if (backend.ddev) {
     // `ddev drush` always targets the project in drupal/ - reject a
     // BASE_URL naming some OTHER DDEV project before running commands
     // against the wrong site.

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -20,6 +20,26 @@ export const ENV_FILE = path.join(ROOT, '.env')
 export const SETUP_LOCK_DIR = path.join(ROOT, '.setup.lock')
 
 /**
+ * What to tell a Windows user instead of failing midway: the local
+ * backend runs a PHP built-in server managed with nohup, lsof, ps and
+ * kill, and provisioning generates OAuth keys through OpenSSL, none of
+ * which works on Windows outside a Linux environment.
+ */
+export const WINDOWS_HELP = [
+  'The local PHP backend is not supported on Windows directly.',
+  '',
+  'Pick one of these instead - all three run this repo unchanged:',
+  '',
+  '  - Dev container: open this folder in VS Code and "Reopen in',
+  '    Container", or run `devpod up .`. Everything is set up for you.',
+  '  - WSL2: clone and run the same commands inside your Linux distro.',
+  '  - DDEV or Lando: start the container backend, put its URL in',
+  '    BASE_URL in .env, then run `npm run setup` for the frontend.',
+  '',
+  'See the Windows section of README.md.',
+].join('\n')
+
+/**
  * The setup lock: two setups in one checkout corrupt nuxt/node_modules
  * and drupal/vendor (two npm/composer processes race in the same dirs).
  * The realistic collision: a dev container's automatic post-create setup
@@ -80,7 +100,7 @@ export function setupLockContentionMessage() {
   )
 }
 
-const IS_WINDOWS = process.platform === 'win32'
+export const IS_WINDOWS = process.platform === 'win32'
 
 // npm is npm.cmd on Windows, and .cmd files must be spawned via a shell.
 const NPM = IS_WINDOWS ? 'npm.cmd' : 'npm'
@@ -168,6 +188,7 @@ export function backendInfo(env = readEnv()) {
   return {
     managed: loopback,
     ddev: host.endsWith('.ddev.site'),
+    lando: host.endsWith('.lndo.site'),
     url,
     host,
     port: Number(parsed.port) || (parsed.protocol === 'https:' ? 443 : 80),
@@ -327,6 +348,21 @@ export function foregroundNpm(args, opts = {}) {
  * start the .devtools PHP server when BASE_URL is loopback and down;
  * never start anything for DDEV/external backends.
  */
+export function ensureOauthClientId(env = readEnv()) {
+  if (env.OAUTH_CLIENT_ID) {
+    return
+  }
+  // Without this, Nuxt dies inside druxt-auth with "requires a clientId
+  // to be provided", which says nothing about what to do. It is empty
+  // whenever provisioning did not finish, so point at that instead.
+  const backend = backendInfo(env)
+  const fix =
+    backend.url && !backend.managed
+      ? "Create a consumer with the backend's own tooling (DDEV: `ddev druxt-add-consumer`,\n  Lando: `lando druxt-add-consumer`) and copy the printed UUID into .env."
+      : 'Run `npm run setup` to provision the backend - it writes this value.'
+  exitWithError(`OAUTH_CLIENT_ID is not set in .env.\n\n  ${fix}`)
+}
+
 export async function ensureBackend() {
   const backend = backendInfo()
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -19,7 +19,9 @@
  */
 
 import {
+  IS_WINDOWS,
   SPLASH,
+  WINDOWS_HELP,
   backendInfo,
   miseAvailable,
   printCommands,
@@ -67,6 +69,16 @@ async function main() {
   // which needs neither PHP nor Composer - never block it on them.
   const backend = backendInfo(env)
   const externalBackend = backend.url && !backend.managed
+
+  if (IS_WINDOWS && !externalBackend) {
+    console.log('  Node side ready.')
+    console.log('')
+    for (const line of WINDOWS_HELP.split('\n')) {
+      console.log(line ? `  ${line}` : '')
+    }
+    console.log('')
+    return
+  }
 
   if (!externalBackend && (!toolAvailable('php') || !toolAvailable('composer'))) {
     console.log('  Node side ready. The backend needs PHP 8.4 + Composer (or DDEV).')

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -26,9 +26,11 @@ import {
   backendInfo,
   acquireSetupLock,
   exitWithError,
+  IS_WINDOWS,
   miseAvailable,
   releaseSetupLock,
   setupLockContentionMessage,
+  WINDOWS_HELP,
   printCommands,
   readEnv,
   runDevtools,
@@ -146,6 +148,10 @@ async function doSetup({ splash }) {
     setupFrontend()
     reportExternalSetup(backend)
     return
+  }
+
+  if (IS_WINDOWS) {
+    throw new Error(WINDOWS_HELP)
   }
 
   checkPrerequisites()

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -5,10 +5,18 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { NUXT_DIR, ensureBackend, exitWithError, foregroundNpm, runNpm } from './lib.mjs'
+import {
+  NUXT_DIR,
+  ensureBackend,
+  ensureOauthClientId,
+  exitWithError,
+  foregroundNpm,
+  runNpm,
+} from './lib.mjs'
 
 async function main() {
   await ensureBackend()
+  ensureOauthClientId()
 
   // `nuxt start` needs the server bundle from a production build; a dev
   // server's .nuxt/ (no dist/server) must not fool this check.


### PR DESCRIPTION
Addresses the Windows issue (#108) and the Lando request (#67), plus a
login failure found while testing the dev container.

## Fix the OAuth login failure on a busy port

Clicking login returned:

```
{"error":"invalid_client","error_description":"Client authentication failed"}
```

Nuxt's dev server does not fail when its port is taken - it falls back
to a random one (`Listen to a random port on dev as a fallback`, in
`@nuxt/server`). The frontend then runs on, say, 3001, so the callback
becomes `http://localhost:3001/callback`, while the Drupal consumer is
registered for `http://localhost:3000/callback`. Simple OAuth rejects
the mismatch, and the error names neither ports nor the callback.

`npm run dev` now refuses to start on a taken port and explains both
ways out.

## Windows (#108)

The reporter hit `openssl_pkey_export(): Cannot get key from parameter
1` during key generation, then `DruxtAuth requires a clientId to be
provided` from the frontend: two confusing errors for one unsupported
configuration.

The local backend cannot work on Windows as it stands - it manages a
PHP built-in server with `nohup`, `lsof`, `ps` and `kill`, and
generates OAuth keys through OpenSSL. Setup now says so immediately and
names the three routes that do work: the dev container, WSL2, or a
container backend. Through `postinstall` it still exits 0, so
`npm install` stays green.

The second error is fixed separately: a missing `OAUTH_CLIENT_ID` now
produces an actionable message from `npm run dev` and `npm run start`,
with different advice for a local and a container backend.

## Lando (#67)

The PR attached to that issue predates Drupal 11 - a `drupal9` recipe
on PHP 8.1 - so it cannot be merged as is.

No script changes were needed. Any non-loopback `BASE_URL` is already
treated as a backend this repository does not manage, so Lando works
the same way DDEV does. What was missing:

- `drupal/.lando.yml`: `drupal11` recipe, PHP 8.4, nginx, MariaDB, with
  `drupal-install` and `druxt-add-consumer` tooling commands
- those commands run the DDEV scripts rather than copies, so the two
  container workflows cannot drift apart
- the install script now derives its keys directory from the working
  directory instead of hardcoding DDEV's mount path
- `npm run drush` proxies through `lando drush`

## Test the environments that had no tests

CI only ever exercised the Docker-free path, so a broken DDEV command,
a Landofile that does not boot, or a dev container failing on first run
would have reached users first. A new workflow covers all three, each
asserting the same end state: site installed, consumer created,
JSON:API answering.

They run on changes to the files they cover, weekly, and on demand -
they are slow. GitHub only: DDEV, Lando and dev containers all have
first-party actions here, while DDEV on GitLab needs a privileged
docker-in-docker runner and Lando has no supported path there.

## Note for review

I have no Docker available, so `.lando.yml` is unverified by execution
- the new Lando job is its first real test. Worth watching that job on
this PR before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lando as a supported development option.
  - Added automated validation for DDEV, Lando, and Dev Container environments.
  - Added configurable frontend port support and automatic environment setup after a fresh clone.
  - Added broader OAuth callback and scope configuration support.

- **Bug Fixes**
  - Improved OAuth validation with actionable guidance.
  - Prevented startup conflicts when the selected port is occupied.
  - Improved Windows setup behavior and guidance.

- **Documentation**
  - Expanded setup instructions for Lando and Windows development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->