### PR TITLE
fix(devcontainer): stop mise resolving to a vfox release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,17 @@
       "version": "8.4",
       "installComposer": true
     },
-    "ghcr.io/devcontainers-extra/features/mise:1": {},
+    // Installed through gh-release rather than the mise feature: that
+    // feature asks for the "latest" jdx/mise release and does not expose
+    // a tag filter, and mise now publishes vfox-* releases from the same
+    // repository. The resolver picked vfox-v2026.8.15, found no matching
+    // asset, and every container build failed. The regex keeps us on
+    // mise's own v-tags while still tracking the newest one.
+    "ghcr.io/devcontainers-extra/features/gh-release:1": {
+      "repo": "jdx/mise",
+      "binaryNames": "mise",
+      "releaseTagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   // Pin the backend port: .devtools/start otherwise auto-discovers the


### PR DESCRIPTION
Dev container builds started failing on `develop` today, and on every
branch that touches `.devcontainer/`:

```
no release exists for repo:jdx/mise and tag: vfox-v2026.8.15
ERROR: Feature "Mise" (ghcr.io/devcontainers-extra/features/mise) failed to install!
```

Nothing here changed. mise publishes `vfox-*` releases from the same
GitHub repository as mise itself, and the mise feature asks `gh-release`
for the `latest` release without exposing a tag filter. The resolver
picked `vfox-v2026.8.15`, which carries no mise binary, and the build
failed.

## The fix

Call `gh-release` directly, with a regex that keeps us on mise's own
`v` tags:

```json
"ghcr.io/devcontainers-extra/features/gh-release:1": {
  "repo": "jdx/mise",
  "binaryNames": "mise",
  "releaseTagRegex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
}
```

The mise feature is a thin wrapper around `gh-release` anyway - it
forwards `version` and nothing else - so this loses nothing and gains
the filter.

Pinning a version was the other option. It would fix today and go
stale, and it would need bumping whenever mise released. This keeps
tracking the newest mise while ignoring the vfox line.

Checked the regex accepts `v2026.8.10` and rejects `vfox-v2026.8.15`.
The dev container job on this PR is the real test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development container configuration to install and expose the `mise` tool through GitHub Releases.
  * Limited release selection to semantic version tags for more consistent setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->