### PR TITLE
fix(drupal): hold decoupled_router below 2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,15 @@ minor is for.
 
 ### Dependencies
 
+- `drupal/decoupled_router` is held below 2.0.7. That release gave
+  `RouterPathTranslatorSubscriber::onPathTranslation()` a `: void` return
+  type, and druxt 1.2.1 declares its three subscribers without one, so
+  the container fails to rebuild: `drush cr` aborts, Drupal keeps serving
+  from the old container, and druxt's subscribers are silently absent.
+  Nothing here required decoupled_router directly, so only the lock stood
+  between an update and a broken site. The constraint comes off when
+  druxt releases a version carrying the fix
+  ([#3618675](https://www.drupal.org/i/3618675)).
 - GitHub Actions on v7: `actions/checkout`, `actions/setup-node`,
   `actions/upload-artifact` and `codecov/codecov-action`.
 - Nuxt dependencies: core-js 3.50.0, dotenv 17, Cypress 15,

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -20,6 +20,7 @@
         "drupal/core-composer-scaffold": "~11",
         "drupal/core-project-message": "~11",
         "drupal/core-recommended": "~11",
+        "drupal/decoupled_router": "^2.0 <2.0.7",
         "drupal/druxt": "^1.2",
         "drupal/simple_oauth": "^6",
         "drush/drush": "^13",
@@ -59,26 +60,46 @@
             }
         },
         "installer-paths": {
-            "web/core": ["type:drupal-core"],
-            "web/libraries/{$name}": ["type:drupal-library"],
-            "web/modules/contrib/{$name}": ["type:drupal-module"],
-            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
-            "web/modules/custom/{$name}": ["type:drupal-custom-module"],
-            "web/profiles/custom/{$name}": ["type:drupal-custom-profile"],
-            "web/themes/custom/{$name}": ["type:drupal-custom-theme"]
+            "web/core": [
+                "type:drupal-core"
+            ],
+            "web/libraries/{$name}": [
+                "type:drupal-library"
+            ],
+            "web/modules/contrib/{$name}": [
+                "type:drupal-module"
+            ],
+            "web/profiles/contrib/{$name}": [
+                "type:drupal-profile"
+            ],
+            "web/themes/contrib/{$name}": [
+                "type:drupal-theme"
+            ],
+            "drush/Commands/contrib/{$name}": [
+                "type:drupal-drush"
+            ],
+            "web/modules/custom/{$name}": [
+                "type:drupal-custom-module"
+            ],
+            "web/profiles/custom/{$name}": [
+                "type:drupal-custom-profile"
+            ],
+            "web/themes/custom/{$name}": [
+                "type:drupal-custom-theme"
+            ]
         },
         "drupal-core-project-message": {
-            "include-keys": ["homepage", "support"],
+            "include-keys": [
+                "homepage",
+                "support"
+            ],
             "post-create-project-cmd-message": [
                 "<bg=blue;fg=white>                                                         </>",
-                "<bg=blue;fg=white>  Congratulations, you’ve installed the Drupal codebase  </>",
+                "<bg=blue;fg=white>  Congratulations, you\u2019ve installed the Drupal codebase  </>",
                 "<bg=blue;fg=white>  from the drupal/recommended-project template!          </>",
                 "<bg=blue;fg=white>                                                         </>",
                 "",
                 "<bg=yellow;fg=black>Next steps</>:",
-
                 "  * Install the site: https://www.drupal.org/docs/8/install",
                 "  * Read the user guide: https://www.drupal.org/docs/user_guide/en/index.html",
                 "  * Get support: https://www.drupal.org/support",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ad0d9677aeafb1d99d2eef32572cce6",
+    "content-hash": "b3421cbdcfecc946cc0ca6023d068677",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Closes nothing here — the fix belongs in druxt. This holds the line until
that release exists.

## What breaks

Decoupled Router 2.0.7 (2026-08-22) gave
`RouterPathTranslatorSubscriber::onPathTranslation()` a `: void` return
type. druxt 1.2.1 declares its three subscribers without one, so PHP
rejects the override:

```
Declaration of Drupal\druxt\EventSubscriber\ViewsPathTranslatorSubscriber::onPathTranslation($event)
must be compatible with ...RouterPathTranslatorSubscriber::onPathTranslation($event): void
```

The failure mode is the bad part. `drush cr` aborts, Drupal keeps serving
from the old container, and druxt's subscribers are silently absent — a
site that quietly stops resolving paths rather than one that falls over.

Tracked upstream as [#3618675](https://www.drupal.org/i/3618675), critical.

## Why this repository was exposed

`drupal/druxt` requires `drupal/decoupled_router: ^2.0`, and nothing here
required it directly, so 2.0.7 was in range and only `composer.lock` stood
between an update and a broken site:

```
$ composer update drupal/decoupled_router
  - Upgrading drupal/decoupled_router (2.0.6 => 2.0.7)
```

A fresh `composer install` was always fine. `composer update`, or a
Renovate bump on its own schedule, was not.

## The constraint

`"drupal/decoupled_router": "^2.0 <2.0.7"`, added as a direct requirement.

A range rather than an exact `2.0.6`: `composer validate --strict` rejects
exact constraints on a package that follows semantic versioning, and this
repository runs that in CI.

## Verified

Built a site with 2.0.7 and druxt from the upstream compatibility branch
to confirm the diagnosis end to end:

| | Result |
| --- | --- |
| druxt 1.2.1 + decoupled_router 2.0.7 | fatal, as above |
| druxt 1.2.x + decoupled_router 2.0.7 | container builds |
| `translate-path?path=/` | HTTP 200, resolves to the frontpage view |

And after the pin:

- `composer update drupal/decoupled_router` — nothing to modify
- `composer update` — decoupled_router untouched
- `composer validate --strict` — passes

## Removing it

When druxt releases a version carrying the fix, drop the constraint and
re-lock. Two things land with it: the `: void` return types, and three
`instanceof CacheableJsonResponse` guards that 2.0.7 made unreachable by
typing `getResponse()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a compatibility constraint for the Drupal decoupled routing component to prevent incompatible updates.
  - Updated the Drupal project template to include the required routing dependency.

- **Chores**
  - Reformatted project configuration for improved readability without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->